### PR TITLE
[루시드] 20220313 풀이 제출

### DIFF
--- a/루시드/20220313.java
+++ b/루시드/20220313.java
@@ -1,0 +1,75 @@
+package AlgorithmStudy.boj7562;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Main {
+
+    static int[] dx = {1, 2, -1, 2, 1, -2, -1, -2};
+    static int[] dy = {2, 1, 2, -1, -2, 1, -2, -1};
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int testNumber = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        int size, nightX, nightY, targetX, targetY;
+        while (testNumber-- > 0) {
+            size = Integer.parseInt(br.readLine());
+            String[] nightPosition = br.readLine().split(" ");
+            nightX = Integer.parseInt(nightPosition[0]);
+            nightY = Integer.parseInt(nightPosition[1]);
+
+            String[] targetPosition = br.readLine().split(" ");
+            targetX = Integer.parseInt(targetPosition[0]);
+            targetY = Integer.parseInt(targetPosition[1]);
+
+            if (nightX == targetX && nightY == targetY) {
+                sb.append(0).append("\n");
+                continue;
+            }
+            sb.append(BFS(size, nightX, nightY, targetX, targetY)).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    private static int BFS(int size, int nightX, int nightY, int targetX, int targetY) {
+        Queue<Point> queue = new LinkedList<>();
+        queue.offer(new Point(nightX, nightY));
+        int result = 0;
+        boolean[][] chk = new boolean[size][size];
+        chk[nightX][nightY] = true;
+
+        while (!queue.isEmpty()) {
+            int tmpSize = queue.size();
+            result++;
+            for (int i = 0; i <tmpSize; i++) {
+                Point poll = queue.poll();
+                for (int j = 0; j < 8; j++) {
+                    int nx = poll.x + dx[j];
+                    int ny = poll.y + dy[j];
+                    if (nx == targetX && ny == targetY) {
+                        return result;
+                    }
+                    if (nx < size && nx >= 0 && ny < size && ny >= 0 && !chk[nx][ny]) {
+                        chk[nx][ny] = true;
+                        queue.offer(new Point(nx, ny));
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    static class Point {
+        int x;
+        int y;
+
+        public Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+}


### PR DESCRIPTION
## 접근방법
- BFS를 활용하여, 타겟에 도달하기까지 최소 횟수를 계산하였습니다.

## 내 풀이의 시간복잡도
- 기본적으로 BFS의 인접 행렬 대상 시간복잡도는 O(V+E) 입니다. 
- 이번 문제의 경우, 최대 체스판 길이는 300이고, 한 위치에서 이동 가능 방향은 8가지 입니다.
- O(V) = 정점의 개수 = 300 * 300 = 90,000입니다.
- O(E) = 간선의 개수 = (300 * 300) * 8 = 720,000입니다.
- 결과로, 최악의 수는 810,000회 입니다.
- 순수 반복 횟수로만 가정할 경우, 1억번 1초 가정 시 약 8.1ms로 계산됩니다. 내부 조건문 등을 고려해서 약 x40 만큼의 복잡도가 곱해져야 하는데, 어떠한 방식으로 계산되는지 잘 모르겠네요 ㅠ

![image](https://user-images.githubusercontent.com/62360009/158065831-1989b81c-3a10-4792-80e9-bf0bdb67d06b.png)

## 참고자료

## 고민사항, 질문

## 리뷰받고 싶은 부분
