### PR TITLE
[익조] 20220314 "백준 - 나이트 이동" 풀이 제출

### DIFF
--- a/익조/20220314
+++ b/익조/20220314
@@ -1,0 +1,64 @@
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+class Main {
+
+    static int I, r, c;
+    static int[] dx = {1, 1, -1, -1, 2, 2, -2, -2}, dy = {2, -2, 2, -2, 1, -1, 1, -1};
+
+    static class Point {
+        int x;
+        int y;
+        int result;
+
+        public Point(int x, int y, int result) {
+            this.x = x;
+            this.y = y;
+            this.result = result;
+        }
+    }
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        int x, y, nx, ny;
+
+        for (int i = 0; i < n; i++) {
+            I = sc.nextInt();
+            x = sc.nextInt();
+            y = sc.nextInt();
+            r = sc.nextInt();
+            c = sc.nextInt();
+
+            boolean[][] visited = new boolean[I][I];
+            visited[x][y] = true;
+            
+            Queue<Point> queue = new LinkedList<>();
+            queue.add(new Point(x, y, 0));
+            
+            while (!queue.isEmpty()) {
+                Point point = queue.poll();
+
+                if (point.x == r && point.y == c) {
+                    System.out.println(point.result);
+                    break;
+                }
+
+                for (int j = 0; j < 8; j++) {
+                    nx = point.x + dx[j];
+                    ny = point.y + dy[j];
+
+                    if ( nx < 0 || nx > I - 1 || ny < 0 || ny > I -1 ) {
+                        continue;
+                    }
+
+                    if (!visited[nx][ny]) {
+                        visited[nx][ny] = true;
+                        queue.add(new Point(nx, ny, point.result + 1));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 접근방법

처음에 DFS로 접근했다가 엄청난 시간 초과가 발생했었고 이러한 문제점을 어떻게 개선할 수 있을지 고민하다가 결국 BFS를 활용하여 접근하게 되었습니다. 하지만 막상 BFS로 접근하긴 했는데 처음 시작 위치에서 방문 처리 안 해줘서 무진장 헤맸네요..😂 딱 한 줄만 추가해줬으면 됐는데 결국 스스로 이걸 못 찾아냈고 마지막에 기술 블로그를 참고해서 발견할 수 있었습니다. 🤣 개인적으로 굉장히 아쉬웠던 문제였습니다. 그래도 뭔가 이 문제를 통해 오랜 시간 삽질을 겪음면서 우리 알고리즘 스터디의 숙원인 DFS와 BFS의 차이에 대해 조금은 느낄 수 있었던 것 같습니다.

## 내 풀이의 시간복잡도

음.. 정확하진 않지만 머리로 이해할 수 있는 정도로는 체스판의 좌표가 최대 300 * 300(=90,000)개 인데, 각 좌표별로 나이트의 이동 가능 경우의 수 8을 곱하여 O(300 * 300 * 8)이고, 여기에 테스트 케이스를 곱하는 게 시간 복잡도가 아닐까 싶었습니다. O(T * 300 * 300 * 8) ※ T는 테이트 케이스 수

