### PR TITLE
[동기] - 20220316 주식 풀이 제출

### DIFF
--- a/동기/20220316.java
+++ b/동기/20220316.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int testCaseCount = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < testCaseCount; i++) {
+            int n = Integer.parseInt(br.readLine());
+            int[] stocks = new int[n];
+            st = new StringTokenizer(br.readLine(), " ");
+            for (int j = 0; j < n; j++) {
+                stocks[j] = Integer.parseInt(st.nextToken());
+            }
+
+            long max = 0;
+            long res = 0;
+            for (int j = n - 1; j >= 0; j--) {
+
+                if (max < stocks[j]) {
+                    max = stocks[j];
+                } else {
+                    res += max - stocks[j];
+                }
+            }
+            System.out.println(res);
+        }
+    }
+}


### PR DESCRIPTION
## 접근방법

- 그리디를 확인 후 탐욕스럽게 원숭이처럼 문제에 접근했습니다. 입력되는 날이 2이상 주어진다길래 숫자를 두 개씩 비교하여 뒤쪽 숫자가 더 크면 앞쪽 숫자 값으로 매수,  반대면 매도하는 식으로 생각했습니다. 디버거로 찍어가며 조건을 하나 둘 추가해주며 예제는 풀었지만 제출하니 광탈이었습니다.
- 2 시간 정도 방황하다 풀이를 보았습니다. 주가를 나타내는 수를 뒤에서 앞으로 (0번째 인덱스로) 오게끔 반복문을 설정하였습니다.
  - `max` 변수를 뒤쪽 숫자부터 값을 비교한 뒤 `max` 의 값보다 주가의 인덱스 값이 크면 `max` 를 업데이트합니다.
  -  주가의 인덱스 값이 더 작아 `max`가 업데이트되지 않으면 max 값과 주가를 뺀 값을 result 에 더해줍니다.

## 내 풀이의 시간복잡도

- 2중 for문을 사용해서.. O(n^2) ..?

## 참고자료

https://velog.io/@sukong/%EB%B0%B1%EC%A4%80-11501-%EC%A3%BC%EC%8B%9D

## 고민사항, 질문

- max 와 result 의 자료형이 int일땐 틀렸는데 long으로 하니 통과가 되었습니다. 저장되는 숫자가 최대 날의 수 * 날 별 주가 == 100억이어서인가요??
