### PR TITLE
[루시드] 20220401 백준 - 거짓말 풀이 제출

### DIFF
--- a/루시드/20220401.java
+++ b/루시드/20220401.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine(), " ");
+        int knowPeopleCount = Integer.parseInt(st.nextToken());
+
+        Set<Integer> set = new HashSet<>();
+        for (int i = 0; i < knowPeopleCount; i++) {
+            set.add(Integer.parseInt(st.nextToken()));
+        }
+
+        List<List<Integer>> partyList = new ArrayList<>();
+
+        for (int i = 0; i < M; i++) {
+            partyList.add(new ArrayList<>());
+        }
+
+        int visitPeopleCount;
+        int curPeople;
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            visitPeopleCount = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < visitPeopleCount; j++) {
+                curPeople = Integer.parseInt(st.nextToken());
+                partyList.get(i).add(curPeople);
+            }
+        }
+
+        boolean chk;
+        do {
+            chk = false;
+            for (List<Integer> list : partyList) {
+                if (set.containsAll(list)) {
+                    continue;
+                }
+                for (Integer value : list) {
+                    if (set.contains(value)) {
+                        chk = true;
+                        set.addAll(list);
+                        break;
+                    }
+                }
+            }
+        } while (chk);
+
+        int result = 0;
+        for (List<Integer> list : partyList) {
+            if (set.containsAll(list)) {
+                continue;
+            }
+            result++;
+        }
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 접근방법
- Set을 만들고, 해당 자료형에 진실을 아는 사람을 갱신합니다.
- 파티를 돌면서 미리 계산된 진실 사람 SET에 사람들이 없을 경우가 거짓말을 쳐도 되는 파티에 해당하므로 result를 증가시킵니다.

## 내 풀이의 시간복잡도

## 고민사항, 질문
- 처음에는 진실을 아는 사람과 같은 파티에 있는 사람을 추가로 Set에 갱신한 후, 파티 참가 여부를 결정했었습니다. 이렇게 될 경우 이후에 추가된 사람의 추가된 사람의 추가된 사람..과 같이 파생된 사람도 결국 진실을 알게된 사람에 추가되야 함을 알았습니다.
- 예를 들어, 4명 중 처음에 3만 진실을 알고 있다고 가정합시다.
```
진실 Set = {3}
party 1 : 1, 4
party 2 : 1, 2
party 3 : 2
party 4 : 2, 3
```

이 때 처음 생각대로 진행하면 진실 Set이 다음과 같이 형성됩니다.

```
진실 Set = {2, 3} -> party 4로 인해 2가 진실 set에 추가된다.
```

따라서 해당 Set을 통해 검증을 진행하면, 다음과 같습니다.
```
진실 Set = {2, 3}
party 1 : 1, 4   -> 거짓말 가능
party 2 : 1, 2   -> 불가
party 3 : 2      -> 불가
party 4 : 2, 3  -> 불가 
```

하지만, 생각해보면 party 2를 검증하는 과정에서 1도 진실을 알게됩니다. 따라서 party 1도 다시 검증될 필요가 있습니다.
결국, 모든 파티에서 거짓말을 할 수 없게 됩니다.

<br>

따라서, 반복해서 진실 Set을 업데이트해야할 필요가 있습니다. 더 이상 진실 Set의 업데이트가 없을 경우에 그제서야 파티 참여를 검증할 수 있게 됩니다.

