### PR TITLE
[익조] 20220405 "프로그래머스 - 전력망을 둘로 나누기" 풀이 제출

### DIFF
--- a/익조/20220405.java
+++ b/익조/20220405.java
@@ -1,0 +1,78 @@
+import java.util.LinkedList;
+import java.util.Queue;
+
+class Solution {
+
+    class Target {
+
+        int nodeA;
+        int nodeB;
+
+        public Target(int nodeA, int nodeB) {
+            this.nodeA = nodeA;
+            this.nodeB = nodeB;
+        }
+
+        public boolean containNode(int nodeA, int nodeB) {
+            return this.nodeA == nodeA || this.nodeA == nodeB || this.nodeB == nodeA
+                || this.nodeB == nodeB;
+        }
+    }
+
+    double result = Double.POSITIVE_INFINITY;
+
+    public int solution(int n, int[][] wires) {
+        if (n == 2 || n == 3) {
+            return n - 2;
+        }
+
+        int countOfWires = wires.length;
+
+        for (int i = 0; i < countOfWires; i++) {
+            int[][] cutWires = cutOneWire(countOfWires, wires, i);
+            int differenceInNumberOfGrids = getDifferenceInNumberOfGrids(cutWires);
+            result = result < differenceInNumberOfGrids ? result : differenceInNumberOfGrids;
+        }
+
+        return (int) result;
+    }
+
+    public int[][] cutOneWire(int countOfWires, int[][] wires, int i) {
+        int[][] cutWires = new int[countOfWires - 1][2];
+        int index = 0;
+
+        for (int j = 0; j < countOfWires; j++) {
+            if (j != i) {
+                cutWires[index++] = wires[j];
+            }
+        }
+
+        return cutWires;
+    }
+
+    public int getDifferenceInNumberOfGrids(int[][] cutWires) {
+
+        Queue<Target> targets = new LinkedList<>();
+        targets.add(new Target(cutWires[0][0], cutWires[0][1]));
+
+        int countOfGridA = 1; // cutWires[0]에 대한 전력망 1개
+        int countOfTotalGrids = cutWires.length;
+
+        boolean[] visited = new boolean[countOfTotalGrids];
+        visited[0] = true;
+
+        while (!targets.isEmpty()) {
+            Target target = targets.poll();
+
+            for (int i = 1; i < countOfTotalGrids; i++) {
+                if (!visited[i] && target.containNode(cutWires[i][0], cutWires[i][1])) {
+                    visited[i] = true;
+                    targets.add(new Target(cutWires[i][0], cutWires[i][1]));
+                    countOfGridA++;
+                }
+            }
+        }
+
+        return Math.abs(countOfTotalGrids - countOfGridA * 2);
+    }
+}


### PR DESCRIPTION
## 접근방법

+ 우선 n = 2이거나 n = 3인 경우 결과값이 정해져있으므로 별도 if문으로 결과값을 반환하도록 했습니다.
+ BFS를 이용해 문제를 해결할 수 있었습니다.
  + BFS 탐색을 하기 앞서 우선 전력망 중 임의의 전선을 하나 끊도록 했고 해당 전력망에 대해 BFS 탐색하도록 했습니다.
  + 이때 BFS 탐색 시 Target이라는 구조체를 만들고 Queue를 활용하여 전력망들을 탐색하면서 연결되는 노드(Target의 노드들에 포함되는 노드)가 있으면 Queue에 add 시키고 방문 처리 시켜주도록 했습니다.
  + 전선을 자를 수 있는 모든 경우에 대해 위 작업을 반복하면서 송전탑의 개수의 차이가 최소인 경우를 구합니다.

https://ikjo.tistory.com/189

## 내 풀이의 시간복잡도

BFS DFS의 시간 복잡도는 어떻게 구해야할지 잘 모르겠습니다...😇

## 참고자료

## 고민사항, 질문

매번 DFS, BFS 등 그래프 탐색 문제를 풀 때마다 뭔가 아이디어는 있는데, 구현을 하는데 엄청난 삽질과 함께 많은 시간이 소요되네요...🤣 이는 물론 아직 제 실력이 미숙하기 때문인 것 같습니다.. 😥 시간도 쫓기고 정신적으로 압박을 받는 실전 코딩테스트에서 뚝딱뚝딱 구현할 정도 되려면 그래프 탐색 문제만 적어도 100~200문제는 풀어봐야 할 것 같습니다..😭

## 리뷰받고 싶은 부분
