### PR TITLE
[후] 20220406 "프로그래머스 - 전력망을 둘로 나누기" 풀이 제출

### DIFF
--- a/후/20220406.java
+++ b/후/20220406.java
@@ -66,21 +66,18 @@ class Solution {
             nodes[wire[0]].connect(nodes[wire[1]]);
         }
 
-        int[] diff = new int[wires.length];
+        int answer = n;
         for (int i = 0; i < wires.length; i++) {
             int[] wire = wires[i];
             nodes[wire[0]].disconnect(nodes[wire[1]]);
             int group = dfs(nodes[1], n);
-            diff[i] = Math.abs((n - group) - group);
+            int diff = Math.abs((n - group) - group);
+            if (diff < answer) {
+                answer = diff;
+            }
             nodes[wire[0]].connect(nodes[wire[1]]);
         }
 
-        int answer = diff[0];
-        for (int d : diff) {
-            if (d < answer) {
-                answer = d;
-            }
-        }
         return answer;
     }
 }

--- a/후/20220406.java
+++ b/후/20220406.java
@@ -1,0 +1,86 @@
+import java.util.*;
+
+class Solution {
+    static class Node {
+
+        int node;
+        LinkedList<Node> connectedNode = new LinkedList<>();
+
+        Node(int node) {
+            this.node = node;
+        }
+
+        void connect(Node node) {
+            this.connectedNode.add(node);
+            node.connectedNode.add(this);
+        }
+
+        void disconnect(Node node) {
+            this.connectedNode.remove(node);
+            node.connectedNode.remove(this);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Node node1 = (Node) o;
+            return node == node1.node;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(node);
+        }
+    }
+
+    public int dfs(Node root, int nodeCount) {
+        boolean[] visited = new boolean[nodeCount + 1];
+        Stack<Node> stack = new Stack<>();
+        visited[root.node] = true;
+        stack.push(root);
+        int count = 1;
+        while (!stack.isEmpty()) {
+            Node node = stack.pop();
+            for (Node n : node.connectedNode) {
+                if (visited[n.node] == false) {
+                    visited[n.node] = true;
+                    stack.push(n);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public int solution(int n, int[][] wires) {
+        Node[] nodes = new Node[n + 1];
+        for (int i = 1; i <= n; i++) {
+            nodes[i] = new Node(i);
+        }
+        for (int[] wire : wires) {
+            nodes[wire[0]].connect(nodes[wire[1]]);
+        }
+
+        int[] diff = new int[wires.length];
+        for (int i = 0; i < wires.length; i++) {
+            int[] wire = wires[i];
+            nodes[wire[0]].disconnect(nodes[wire[1]]);
+            int group = dfs(nodes[1], n);
+            diff[i] = Math.abs((n - group) - group);
+            nodes[wire[0]].connect(nodes[wire[1]]);
+        }
+
+        int answer = diff[0];
+        for (int d : diff) {
+            if (d < answer) {
+                answer = d;
+            }
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 접근방법
1. 주어진 전력망을 둘로 나누는 문제이므로 두 전력망의 송전탑 개수(n)의 차이는 n보다 차이보다 클 수 없으므로 정답(answer)을 n으로 초기화
2. 주어진 wires를 순회하며 전선을 하나 끊음
3. bfs를 이용하여 연결되어있는 전력망의 노드 개수를 count -> 한 전력망의 송전탑 개수(group)
4. |(n - group) - group|를 answer과 비교하며 더 적은 경우 answer를 갱신
    - 첫 풀이는 이렇게 구하지 않았고 배열에 송전탑 개수의 차이를 저장해두고, 마지막에 배열을 한번 탐색하며 최소값을 찾았었는데 접근방법을 적으면서 개선점이 떠올라서 개선하였습니다ㅎㅎ
6. 끊었던 전선을 다시 연결(2로 돌아가 주어진 wires를 끝까지 순회할 때까지 반복)

## 내 풀이의 시간복잡도
메이비 n^2...?! (주어진 노드(n)에 연결된 노드들(최대 n)을 전부 탐색해야 하기에...?!)

