### PR TITLE
[후] 20220511 "백준 - 회의실 배정" 풀이 제출

### DIFF
--- a/후/20220511.java
+++ b/후/20220511.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class Main {
+
+    static class Conference implements Comparable<Conference> {
+
+        int start;
+        int end;
+
+        public Conference(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public int compareTo(Conference o) {
+            if (this.end < o.end) {
+                return -1;
+            } else if (this.end == o.end) {
+                return Integer.compare(this.start, o.start);
+            } else {
+                return 1;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Conference{" +
+                "start=" + start +
+                ", end=" + end +
+                '}';
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine()); // 회의의 수
+        ArrayList<Conference> conferences = new ArrayList<>(N);
+        while (N-- > 0) {
+            String[] times = br.readLine().split(" ");
+            int startTime = Integer.parseInt(times[0]);
+            int endTime = Integer.parseInt(times[1]);
+            conferences.add(new Conference(startTime, endTime));
+        }
+        br.close();
+
+        Collections.sort(conferences);
+
+        int answer = 0;
+        int time = 0;
+        for (Conference conference : conferences) {
+            if (conference.start >= time) {
+                answer++;
+                time = conference.end;
+            }
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
## 접근방법
#### 💩 실패 접근방법
- 회의실을 최대한 많이 사용하려면 `회의실 사용 시간이 짧은 회의부터 배정`하면 될거라 생각했습니다.
- 회의실 사용 시간(회의 종료시간 - 회의 시작시간)의 오름차순으로 정렬하여 배정 가능 여부를 판단하며 카운팅하였습니다.
- 애초에 로직이 틀리기도 했고, 회의를 별도의 클래스를 정의하여 사용해서 그런지 메모리 초과가 나기도 하였습니다ㅠ_ㅠ
#### ✅ 성공 접근방법
- 기존의 로직이 틀렸다는건 알겠는데 그럼 도대체 어떻게 풀어야할지 모르겠어서 제리의 도움을 받았습니다.
- 키포인트는 회의실 사용 시간이 아닌 `회의 종료시간`으로, 회의 종료시간의 오름차순 다음으로 회의 시작시간의 오름차순으로 정렬하여 배정 가능 여부를 판단하며 카운팅하였습니다.
- 이 때, 배정 가능 여부는 직전에 배정한 회의 종료시간보다 지금 가능 여부를 판단하는 회의의 시작시간이 같거나 크면 가능한 것으로 판단합니다.
 
## 내 풀이의 시간복잡도
O(n log n)

## 참고자료
제리의 브레인

## 고민사항, 질문
메모리때문에 별도의 클래스를 정의하지 않고 풀어보고 싶었는데, 그럼 이차원 배열을 어떻게 정렬해야할지 모르겠어서 결국 Conference 클래스를 사용했네요ㅠㅠ 평소에 알고리즘 문제를 풀 때 커스텀 타입을 만들어 문제를 풀곤 하는데 이번에 제리에게 이것저것 조언을 많이 받으면서 이런 버릇을 고쳐야겠다는 생각이 들었습니다ㅠ_ㅠ
