### PR TITLE
[루시드] 20220511 백준 - 회의실 배정 풀이 제출

### DIFF
--- a/루시드/20220511.java
+++ b/루시드/20220511.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        List<Conference> list = new ArrayList<>();
+
+        while (N-- > 0) {
+            String[] s = br.readLine().split(" ");
+            list.add(new Conference(Integer.parseInt(s[0]), Integer.parseInt(s[1])));
+        }
+
+        list.sort((o1, o2) -> {
+            if (o1.endTime != o2.endTime) {
+                return o1.endTime - o2.endTime;
+            }
+            return o1.startTime - o2.startTime;
+        });
+
+        int endTime = list.get(0).endTime;
+        int count = 1;
+        
+        for (int i = 1; i < list.size(); i++) {
+            Conference tmp = list.get(i);
+            if (tmp.startTime < endTime) {
+                continue;
+            }
+            endTime = tmp.endTime;
+            count++;
+        }
+        System.out.println(count);
+    }
+
+    static class Conference {
+        int startTime;
+        int endTime;
+
+        public Conference(int startTime, int endTime) {
+            this.startTime = startTime;
+            this.endTime = endTime;
+        }
+    }
+}


### PR DESCRIPTION
## 접근방법
- 끝시간 기준 오름차순 정렬 -> 끝시간 동일 시 시작 시간 기준 오름차순으로 정렬하였습니다.
- 이후, 맨 첫 번째 회의의 끝시간을 기준으로 리스트를 탐색하며 가장 빨리 시작할 수 있는 회의를 선택하고, 해당 회의의 끝시간으로 다시 기존의 끝시간을 갱신합니다.

## 내 풀이의 시간복잡도
- O(NlogN)

## 참고자료
https://brandpark.github.io/java/2021/01/06/arrays_sort2.html

