### PR TITLE
[익조] 20220519 "백준 - 알파벳" 풀이 제출

### DIFF
--- a/익조/20220519.java
+++ b/익조/20220519.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+class Main {
+
+    static int r, c, result = 0;
+    static String[][] board;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        board = new String[r][c];
+
+        for (int i = 0; i < r; i++) {
+            board[i] = br.readLine().split("");
+        }
+
+        dfs(0, 0, 0, "");
+
+        System.out.println(result);
+    }
+
+    public static void dfs(int x, int y, int count, String visited) {
+        if (x < 0 || x > r - 1 || y < 0 || y > c - 1 || visited.contains(board[x][y])) {
+            result = Math.max(count, result);
+            return;
+        }
+
+        visited += board[x][y];
+        count++;
+
+        dfs(x + 1, y, count, visited);
+        dfs(x - 1, y, count, visited);
+        dfs(x, y + 1, count, visited);
+        dfs(x, y - 1, count, visited);
+    }
+}


### PR DESCRIPTION
## 접근방법

+ 문제 자체만 봤을 때 바로 DFS로 풀어야 겠다는 생각이 들었습니다.(또FS 소리 들을까봐 민망하군요..ㅋㅋ)
+ 깊이 우선 탐색을 통해 (0,0) 지점에서 출발했을 때 탐색할 수 있는 모든 경로에 대해 탐색이 끝났을 때 이동한 칸 수를 검사하여 모든 경로 중 가장 이동을 많이 한 횟수를 구하도록 했습니다.
+ 이 문제의 경우 기존 DFS랑 접근을 다르게 했었던 게 별도의 방문 처리는 하지 않았다는 점입니다. 왜냐하면 모든 경로에 대해 검사해야하기 때문에 방문처리를 하다보면 다른 경로의 탐색에 영향을 끼칠 수 있기 때문입니다. 사실 애초에 종료 조건 자체가 기존 보드판의 범위를 벗어나는 경우를 포함하여 `이미 밟은 알파벳을 또 밟을 경우`이기 때문에 다른 방법으로 탐색 종료를 해줄 필요가 있었습니다.
+ 이를 위하여 당초에는 HashMap을 사용하여 알파벳을 탐색할 때마다 해당 알파벳을 put해주고 기존에 밟았는지 여부를 containsKey 메서드를 이용하고자 했습니다. 하지만 HashMap의 경우 객체기 때문에 재귀 탐색 시 다른 경로들과 자료를 공유하는 이슈가 있었습니다. 그리하여 성능이 나쁘더라도 String 문자열 객체를 사용했습니다.

## 내 풀이의 시간복잡도

시간 제한을 over 했는데 일단 통과는 됐네요.. 시간복잡도를 개선할  수 있는 방법을 좀 더 생각해봐야 할 것 같습니당..

## 참고자료

## 고민사항, 질문

## 리뷰받고 싶은 부분
