### PR TITLE
[익조] 20220616 "프로그래머스 - 메뉴 리뉴얼" 풀이 제출

### DIFF
--- a/익조/20220616.java
+++ b/익조/20220616.java
@@ -1,0 +1,70 @@
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class Solution {
+
+    Map<String, Integer> countByMenuCombination = new HashMap<>();
+
+    public String[] solution(String[] orders, int[] course) {
+
+        List<String> result = new ArrayList<>();
+
+        for (int sizeOfCourse : course) {
+            for (String order : orders) {
+                String[] menus = order.split("");
+                boolean[] choicesOfMenu = new boolean[menus.length];
+                Arrays.sort(menus);
+                dfs(0, 0, sizeOfCourse, menus, choicesOfMenu);
+            }
+
+            int maxCountOfOrder = countByMenuCombination.keySet().stream()
+                .filter(menuCombination -> menuCombination.length() == sizeOfCourse)
+                .map(menuCombination -> countByMenuCombination.get(menuCombination))
+                .filter(count -> count > 1).mapToInt(x -> x)
+                .max().orElse(0);
+            result.addAll(
+                countByMenuCombination.keySet().stream()
+                    .filter(menuCombination -> menuCombination.length() == sizeOfCourse && countByMenuCombination.get(menuCombination) == maxCountOfOrder)
+                    .collect(Collectors.toList())
+            );
+        }
+
+        Collections.sort(result);
+
+        return result.toArray(new String[0]);
+    }
+
+    public void dfs(int depth, int cnt, int sizeOfCourse, String[] menus, boolean[] choicesOfMenu) {
+        if (cnt == sizeOfCourse) {
+            String menuCombination = getMenuCombination(menus, choicesOfMenu);
+            countByMenuCombination.put(menuCombination, countByMenuCombination.getOrDefault(menuCombination, 0) + 1);
+            return;
+        }
+
+        if (depth == menus.length) {
+            return;
+        }
+
+        choicesOfMenu[depth] = true;
+        dfs(depth + 1, cnt + 1, sizeOfCourse, menus, choicesOfMenu);
+        choicesOfMenu[depth] = false;
+        dfs(depth + 1, cnt, sizeOfCourse, menus, choicesOfMenu);
+    }
+
+    public String getMenuCombination(String[] menus, boolean[] visited) {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < menus.length; i++) {
+            if (visited[i]) {
+                sb.append(menus[i]);
+            }
+        }
+
+        return sb.toString();
+    }
+  


### PR DESCRIPTION
## 접근방법

+  DFS를 이용하여 손님들이 주문한 메뉴들(String[] orders)로부터 구성 가능한 메뉴의 조합을 구합니다.
   + 이때 조합의 개수는 문제에서 주어지는 단품 메뉴 개수(int[] course)를 이용하여 정합니다.
+ HashMap을 이용하여 메뉴의 조합별 개수를 카운팅(counting))합니다.
+ 가장 많이 조합되었던 메뉴의 조합을 탐색합니다.

상세 : https://ikjo.tistory.com/195

※ 이 문제를 풀기 전에 루시드가 출제해줬던 로또 문제를 풀어본 것이 많은 도움이 됐었습니다 ㅎㅎ

## 내 풀이의 시간복잡도

## 참고자료

## 고민사항, 질문

## 리뷰받고 싶은 부분
