### PR TITLE
[제리] 20220726 "백준 - 미친 로봇" 풀이 제출

### DIFF
--- a/제리/20220726-01.java
+++ b/제리/20220726-01.java
@@ -1,0 +1,68 @@
+package Baekjoon.num1405;
+
+/*
+	문제    : BOJ 미친 로봇
+    유형    : dfs
+	난이도   : MEDIUM(G5)
+	시간    : 20m
+	uri    : https://www.acmicpc.net/problem/1405
+    날짜    : 22.07.24(o)
+    refer  :
+*/
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int n;
+	static boolean[][] map;
+	static int[] dx = {1, -1, 0, 0};
+	static int[] dy = {0, 0, -1, 1};
+	static double[] percent = new double[4];
+	static double answer;
+	static double[] sequence;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		percent[0] = Double.parseDouble(st.nextToken()) * 0.01;
+		percent[1] = Double.parseDouble(st.nextToken()) * 0.01;
+		percent[2] = Double.parseDouble(st.nextToken()) * 0.01;
+		percent[3] = Double.parseDouble(st.nextToken()) * 0.01;
+
+		map = new boolean[2 * n + 1][2 * n + 1];
+		sequence = new double[n];
+
+		map[n][n] = true;
+		dfs(n, n, 0);
+		System.out.println(answer);
+	}
+
+	private static void dfs(int x, int y, int depth) {
+		if (depth == n) {
+			double tmp = 1;
+			for (double s : sequence) {
+				tmp *= s;
+			}
+			answer += tmp;
+			return;
+		}
+
+		for (int i = 0; i < 4; i++) {
+			int newX = x + dx[i];
+			int newY = y + dy[i];
+			if (!map[newX][newY]) {
+				sequence[depth] = percent[i];
+				map[newX][newY] = true;
+				dfs(newX, newY, depth + 1);
+				map[newX][newY] = false;
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
## 접근방법

문제 조건에 소수점 9자리까지만 체크한다고 되어 있어서 double로 해결이 가능했네요 :)

dfs를 통해서 지나갔던 길을 지나지 않고 n에 해당하는 깊이까지 이동했을 경우가 겹치지 않은 동선인 것을 활용해서 풀었습니다.

동쪽으로 이동하면 동쪽확률을, 서쪽이면 서쪽확률 ... 을 계속 sequence 배열에 저장하고 있다가 겹치지 않은 동선이면 sequence 배열에 있는 확률들을 곱해서 모든 경우의 확률을 구했습니다.
