### PR TITLE
🔀 [아더] 20220804 BOJ_1806_부분합 문제 풀이 제출

### DIFF
--- a/아더/20220804.java
+++ b/아더/20220804.java
@@ -1,0 +1,63 @@
+package 아더;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_1806_부분합 {
+
+    static int N, S, answer;
+    static int[] nums;
+
+    public static void main(String[] args) {
+        try {
+            input();
+            solve();
+            print();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void print() {
+        if (answer == N + 1) {
+            System.out.println(0);
+        } else {
+            System.out.println(answer);
+        }
+    }
+
+    private static void solve() {
+        int R = 0;
+        int sum = 0;
+
+        for (int L = 1; L <= N; L++) {
+            sum -= nums[L - 1];
+
+            while (R + 1 <= N && sum < S) {
+                R++;
+                sum += nums[R];
+            }
+
+            if (sum >= S) {
+                answer = Math.min(answer, R - L + 1);
+            }
+        }
+    }
+
+    private static void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] split = br.readLine().split(" ");
+        N = Integer.parseInt(split[0]);
+        S = Integer.parseInt(split[1]);
+        answer = N + 1;
+
+        nums = new int[N + 1];
+
+        split = br.readLine().split(" ");
+        for (int i = 1; i <= N; i++) {
+            nums[i] = Integer.parseInt(split[i - 1]);
+        }
+    }
+}


### PR DESCRIPTION
## 접근방법
1. 처음엔 누적합으로 계산해보려고 시도했습니다. 입력받을 때 배열을 누적합으로 해놓고 계산하다보니 첫 번째 인덱스를 예외처리해줘야 하는 부분이 많아져서 배열 입력을 그대로 받고 처리했습니다.
2. 투포인터 개념을 사용했습니다. L인덱스와 R인덱스를 조작하며 합계가 기준을 넘을 때만 정답을 최솟값으로 갱신할 수 있도록 했습니다.

## 내 풀이의 시간복잡도
투포인터라 `O(N^2)` 보다는 작을 것 같습니다!
