### PR TITLE
🔀 [후] 20220814 "백준 - 부분합" 풀이 제출

### DIFF
--- a/후/20220814.java
+++ b/후/20220814.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer tokenizer = new StringTokenizer(in.readLine());
+		final int N = Integer.parseInt(tokenizer.nextToken()); // 수열의 길이
+		final int S = Integer.parseInt(tokenizer.nextToken()); // 연속된 수들의 부분합
+		int[] arr = new int[N + 1];
+		int[] prefixSum = new int[N + 1];
+		tokenizer = new StringTokenizer(in.readLine());
+		for (int i = 1; i <= N; i++) {
+			arr[i] = Integer.parseInt(tokenizer.nextToken());
+			prefixSum[i] = prefixSum[i - 1] + arr[i];
+		}
+		in.close();
+
+		int answer = Integer.MAX_VALUE;
+		int start = 1;
+		int end = 1;
+		while (end <= N) {
+			if (prefixSum[end] - prefixSum[start - 1] >= S) {
+				answer = Math.min(answer, end - start +1);
+				start++;
+			} else {
+				end++;
+			}
+		}
+		System.out.println((answer == Integer.MAX_VALUE) ? 0 : answer);
+	}
+}


### PR DESCRIPTION
## 접근방법
(1차시도) 완전 탐색으로 시도했으나 시간초과로 실패하였습니다.

동빈나의 투포인터, 부분합 강의를 보고 다시 재도전해보았습니다!

1. 시작점과 끝점을 첫 번째 원소의 인덱스로 설정
2. 현재 부분 합이 S이상이라면 시작점과 끝점 사이의 길이를 구하여 최소값을 갱신한다.
3. 현재 부분 합이 S보다 작다면 end를 1 증가시킨다.
4. 현재 부분 합이 S보다 크다면 start를 1 증가시킨다.
5. 모든 경우를 확인할 때까지 2번부터 4번까지의 과정을 반복한다.

## 내 풀이의 시간복잡도
O(N)

## 참고자료
https://www.youtube.com/watch?v=rI8NRQsAS_s
