### PR TITLE
[익조] 20220824 "프로그래머스 - 두 큐 합 같게 만들기" 풀이 제출

### DIFF
--- a/익조/20220824.java
+++ b/익조/20220824.java
@@ -1,0 +1,52 @@
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Solution {
+
+    public int solution(int[] queue1, int[] queue2) {
+        int length = queue1.length;
+        Queue<Integer> q1 = new LinkedList<>();
+        Queue<Integer> q2 = new LinkedList<>();
+
+        for (int i = 0; i < length; i++) {
+            q1.add(queue1[i]);
+            q2.add(queue2[i]);
+        }
+        
+        long sum1 = getSum(q1), sum2 = getSum(q2);
+        int result, count = 0, delay = 0;
+        while (true) {
+            if (delay > 2 * length + 2) {
+                return -1;
+            } else if (sum1 > sum2) {
+                Integer i1 = q1.poll();
+                q2.add(i1);
+                sum1 -= i1;
+                sum2 += i1;
+                count++;
+            } else if (sum1 < sum2) {
+                Integer i2 = q2.poll();
+                q1.add(i2);
+                sum1 += i2;
+                sum2 -= i2;
+                count++;
+            } else {
+                result = count;
+                break;
+            }
+
+            delay++;
+        }
+
+        return result;
+    }
+
+    private long getSum(Queue<Integer> queue) {
+        long sum = 0;
+        for (Integer i : queue) {
+            sum += i;
+        }
+
+        return sum;
+    }
+}

--- a/익조/20220824.java
+++ b/익조/20220824.java
@@ -14,9 +14,9 @@ public class Solution {
         }
         
         long sum1 = getSum(q1), sum2 = getSum(q2);
-        int result, count = 0, delay = 0;
+        int result, count = 0;
         while (true) {
-            if (delay > 2 * length + 2) {
+            if (count > 2 * length + 2) {
                 return -1;
             } else if (sum1 > sum2) {
                 Integer i1 = q1.poll();
@@ -34,8 +34,6 @@ public class Solution {
                 result = count;
                 break;
             }
-
-            delay++;
         }
 
         return result;


### PR DESCRIPTION
## 접근방법

앗 2일전에 풀었던 문제네용..ㅋㅋ

+ https://ikjo.tistory.com/318


+ 주어지는 배열을 큐로 변환해서 풀었습니다.
+ 이후 두 큐의 합(sum1, sum2)을 구하고 sum1과 sum2를 비교하면서 같아질 때까지 디큐 및 엔큐를 해주면서 작업 횟수를 카운팅합니다.
+ 이때 처음 접근했었던 방법으로는 브루트 포스 방식으로 `sum1 = sum2일 수 있는` 모든 경우의 수를 따져줬었는데(결과는 시간 초과), 사실 그럴 필요도 없었던 게 앞선 디큐 및 엔큐 작업을 해주면서 가장 먼저 `sum1 = sum2` 조건을 만족한 경우의 작업 횟수가 `최소 작업 횟수`이기 때문입니다.
  + 이후 더 이상의 연산은 필요없으므로 무한 반복문에서 break시킵니다.
+ 아울러 처음에는 디큐 및 엔큐할 때마다 매번 큐를 순회하면서 합을 구해줬었는데, sum1과 sum2는 한번만 구하고 이를 변수에 담은 후 디큐, 엔큐되는 값들을 이 변수에 반영해주기만 하면, 굳이 매번 큐를 순회할 필요가 없게됩니다.
+ 어떤 방법으로도 각 큐의 원소 합을 같게 만들 수 없는 경우에 대해서도 고려(무한 반복문 탈출 조건 설정)해주어야 하는데, 이는 가장 오래 순회될 수 있는 길이를 찾아야합니다.

```
if q1과 q2의 길이가 5, then

q1 : _ _ _ x _  ->  _                  ->  _ _ _ _ _ _ _ _ _ 
q2 : _ _ _ _ _  ->  _ _ _ _ _ _ _ _ x  ->  x

        최초            4번 작업                8번 작업   

위와 같이 최초 q1에 있는 x 요소와 나머지 요소들의 합이 같다고 가정했을 때,

필요한 작업 횟수는 총 12번의 작업이 필요합니다.

만일 이 12번의 작업으로도 sum1 = sum2 조건이 충족하지 않는다면,

곧이어 13번의 작업을 수행할 것이고 이는 불필요한 앞선 작업을 반복하게 되는 꼴이 됩니다.

따라서 13번을 수행했을 떄 끊어줘야되고 이를 반복문 탈출 조건 식으로 나타나내면, 아래와 같습니다.

count(작업 횟수) > 2 * 최초 큐의 길이 + 2 

```

## 내 풀이의 시간복잡도

## 참고자료

## 고민사항, 질문

## 리뷰받고 싶은 부분
