### PR TITLE
🔀 [아더] 20220905 "프로그래머스 - 뉴스 클러스터링" 풀이 제출

### DIFF
--- a/아더/20220905.java
+++ b/아더/20220905.java
@@ -1,0 +1,73 @@
+package 아더;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PRO_17677_뉴스클러스터링 {
+
+    public static void main(String[] args) {
+        PRO_17677_뉴스클러스터링 pro = new PRO_17677_뉴스클러스터링();
+
+        String str11 = "FRANCE";
+        String str12 = "french";
+        String str21 = "handshake";
+        String str22 = "shake hands";
+        String str31 = "aa1+aa2";
+        String str32 = "AAAA12";
+        String str41 = "E=M*C^2";
+        String str42 = "e=m*c^2";
+        String str51 = "BAAAA"; // BA AA AA AA
+        String str52 = "AAA";   // AA AA
+
+        System.out.println(pro.solution(str11, str12));
+        System.out.println(pro.solution(str21, str22));
+        System.out.println(pro.solution(str31, str32));
+        System.out.println(pro.solution(str41, str42));
+        System.out.println(pro.solution(str51, str52)); // 32768
+    }
+
+    public int solution(String str1, String str2) {
+        int answer = 0;
+        List<String> str1Lists = new ArrayList<>();
+        List<String> str2Lists = new ArrayList<>();
+        double list1Count = 0;
+        double list2Count = 0;
+
+        for (int i = 0; i < str1.length() - 1; i++) {
+            String sub = str1.substring(i, i + 2);
+            if (isAlpha(sub)) {
+                str1Lists.add(sub.toLowerCase());
+            }
+        }
+        list1Count = str1Lists.size();
+
+        for (int i = 0; i < str2.length() - 1; i++) {
+            String sub = str2.substring(i, i + 2);
+            if (isAlpha(sub)) {
+                str2Lists.add(sub.toLowerCase());
+            }
+        }
+        list2Count = str2Lists.size();
+
+        double intersectionCount = 0;
+        for (String str1List : str1Lists) {
+            if (str2Lists.contains(str1List)) {
+                intersectionCount++;
+                str2Lists.remove(str1List);
+            }
+        }
+
+        double unionCount = (list1Count + list2Count) - intersectionCount;
+        if (unionCount == 0) {
+            return 65536;
+        }
+
+        answer = (int)((intersectionCount / unionCount) * 65536);
+
+        return answer;
+    }
+
+    public static boolean isAlpha(String str) {
+        return str != null && str.chars().allMatch(Character::isLetter);
+    }
+}


### PR DESCRIPTION
## 접근방법
1. 먼저 다중집합을 구하기 위해 리스트를 두 개 선언하고 알파벳으로만 이루어진 집합들을 리스트에 추가했습니다.
2. 다음은 교집합을 구하는 부분인데 이 부분에서 엣지케이스를 잘 처리해줘야 했습니다. 단순히 하나의 집합원소에서 다른 집합에 존재하는지 판단하는 것이 아니라 존재한다면 원소를 지워주는 작업이 필요했습니다! (`str1 = "BAAAA", str2 = "AAA", answer = 32768`)
3. 합집합을 구할 땐 두 리스트의 합을 구한 뒤 교집합의 크기를 빼주는 것이 핵심입니다.
4. 마지막으론 다시 한 번 엣지케이스를 걸러주면 끝!(합집합이 0일 때 65536 리턴!)

## 내 풀이의 시간복잡도
`O(N^2)` 일듯요?