### PR TITLE
[익조] 20221001 "백준 - 회전 초밥" 풀이 제출

### DIFF
--- a/익조/20221001.java
+++ b/익조/20221001.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken()), d = Integer.parseInt(st.nextToken()),
+            k = Integer.parseInt(st.nextToken()), c = Integer.parseInt(st.nextToken());
+
+        int[] fishes = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            fishes[i] = Integer.parseInt(br.readLine());
+        }
+
+        int result = 0;
+
+        Set<Integer> pick = new HashSet<>();
+
+        for (int i = 0; i < n; i++) {
+            for (int j = i; j < i + k; j++) {
+                pick.add(fishes[j % n]);
+            }
+
+            pick.add(c);
+
+            int count = pick.size();
+            result = Math.max(result, count);
+            if (d == count) {
+                break;
+            }
+
+            pick.clear();
+        }
+
+        print(result);
+
+        bw.flush();
+        bw.close();
+    }
+
+    private static void print(long value) throws IOException {
+        bw.write(String.valueOf(value));
+        bw.write("\n");
+    }
+}


### PR DESCRIPTION
## 접근방법

+ 해시와 브루트포스를 이용하여 해결할 수 있었습니다.
+ 초밥을 순차적으로 k개만큼 선택한 후 HashSet에 add한 후 추가로 c 쿠폰에 해당하는 초밥도 add하여,
+ 해당 HashSet의 크기를 최대값으로 초기화해주도록 했습니다. 이때 크기가 d와 동일하다면 더이상 탐색할 필요가 없으므로 탐색을 중단합니다.
+ 뭔가 해시를 이용하면 되겠다 생각하고 풀어봤는데, 알고보니 두 포인터를 이용한 문제였네요...ㅋㅋ (어쩐지 1초 넘게 나오더라..)
+ 두 포인터를 이용해서도 접근해보겠습니다. 😅

## 내 풀이의 시간복잡도

## 참고자료

## 고민사항, 질문

## 리뷰받고 싶은 부분
