### PR TITLE
🔀 [제리] 20221004 "백준 - 회전 초밥" 풀이 제출

### DIFF
--- a/제리/20221004-2.java
+++ b/제리/20221004-2.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = Integer.valueOf(st.nextToken());
+		int d = Integer.valueOf(st.nextToken());
+		int k = Integer.valueOf(st.nextToken());
+		int c = Integer.valueOf(st.nextToken());
+		int[] sushi = new int[n];
+
+		for (int i = 0; i < n; i++) {
+			sushi[i] = Integer.valueOf(br.readLine());
+		}
+
+		int[] ate = new int[d + 1];
+		int count = 0;
+		for (int i = 0; i < k; i++) {
+			if (ate[sushi[i]] == 0) {
+				count++;
+			}
+
+			ate[sushi[i]]++;
+		}
+
+		int maxLen = count;
+
+		for (int i = 1; i < n; i++) {
+			if (maxLen <= count) {
+				if (ate[c] == 0) {
+					maxLen = count + 1;
+				} else {
+					maxLen = count;
+				}
+			}
+
+			int end = (i + k - 1) % n;
+			if (ate[sushi[end]] == 0) {
+				count++;
+			}
+			ate[sushi[end]]++;
+
+			ate[sushi[i - 1]]--;
+			if (ate[sushi[i - 1]] == 0) {
+				count--;
+			}
+		}
+
+		System.out.println(maxLen);
+	}
+}


### PR DESCRIPTION
## 접근방법

계속 조금씩 풀이가 제대로 되지 않아서 답을 참고했습니다.. 머리가 잘 안도네요 ㅠㅠ

초기에 k에 따라 회전 초밥에 존재하는 스시의 종류를 먼저 카운트 한 이후에 start 지점을 이동시키면서 계속 먹는 스시의 종류를 카운트했습니다.

카운트 할 때 스시의 종류에 쿠폰 번호에 해당하는 스시가 포함되어 있다면 그냥 두고 포함되어 있지 않다면 maxLen을 1 증가시켰습니다.