### PR TITLE
[피오] 20221108 백준 - 그림 풀이 제출

### DIFF
--- a/221108.java
+++ b/221108.java
@@ -1,0 +1,61 @@
+package baekjoon.main_1926;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    private static int n;
+    private static int m;
+    private static int[][] board;
+    private static boolean[][] visited;
+    private static int[] dy = {1, 0, -1, 0};
+    private static int[] dx = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] s = br.readLine().split(" ");
+        n = Integer.parseInt(s[0]);
+        m = Integer.parseInt(s[1]);
+        board = new int[n][m];
+        visited = new boolean[n][m];
+
+        StringTokenizer st;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            for (int j = 0; j < m; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int cntOfPaints = 0;
+        int maxSizeOfPaint = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (!visited[i][j] && board[i][j] == 1) {
+                    maxSizeOfPaint = Math.max(maxSizeOfPaint, dfs(i, j, 1));
+                    cntOfPaints++;
+                }
+            }
+        }
+        System.out.println(cntOfPaints);
+        System.out.println(maxSizeOfPaint);
+    }
+
+    public static int dfs(int y, int x, int acc) {
+        visited[y][x] = true;
+ 
+        for (int i = 0; i < 4; i++) {
+            int nextY = y + dy[i];
+            int nextX = x + dx[i];
+
+            if (0 <= nextY && 0 <= nextX && nextY < n && nextX < m
+                && !visited[nextY][nextX] && board[nextY][nextX] == 1) {
+                acc = dfs(nextY, nextX, ++acc);
+            }
+        }
+        return acc;
+    }
+}


### PR DESCRIPTION
## 접근방법
dfs를 이용하여 그림의 개수를 세주었고, dfs를 재귀호출할 때 그림 size 파라미터 값을 1씩 증가시켜서 넘겨주다가 
dfs메서드가 그 값을 리턴하도록 하였습니다.

## 내 풀이의 시간복잡도

## 참고자료

## 고민사항, 질문

## 리뷰받고 싶은 부분
