### PR TITLE
[동기] 20221115 백준 - 벽 부수고 이동(하)기 풀이 제출

### DIFF
--- a/동기/20221115.java
+++ b/동기/20221115.java
@@ -1,0 +1,78 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int[] dx = {0, 0, 1, -1};
+    int[] dy = {1, -1, 0, 0};
+    boolean[][][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] split = br.readLine().split(" ");
+        int n = Integer.parseInt(split[0]);
+        int m = Integer.parseInt(split[1]);
+        
+        if (n - 1 == 0 && m - 1 == 0) {
+            System.out.println(1);
+            System.exit(0);
+        }
+
+        StringTokenizer st;
+        String[][] map = new String[n][m];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            map[i] = st.nextToken().split("");
+        }
+
+        Main s = new Main();
+        System.out.println(s.solution(n, m, map));
+
+    }
+
+    public int solution(int n, int m, String[][] map) {
+        visited = new boolean[n][m][2];
+        int[][] dist = new int[n][m];
+
+        Queue<int[]> q = new LinkedList<>();
+        q.offer(new int[]{0, 0, 0});
+        while (!q.isEmpty()) {
+            int[] current = q.poll();
+            for (int i = 0; i < 4; i++) {
+                int nx = dx[i] + current[0];
+                int ny = dy[i] + current[1];
+
+                if (nx < 0 || ny < 0 || nx >= n || ny >= m) {
+                    continue;
+                }
+
+                // 이동할 위치가 벽이라면
+                // [x][y][0] = 벽을 깨지 않고 이동
+                // [x][y][1] = 벽을 깨고 이동
+                if (map[nx][ny].equals("1")) {
+                    if (current[2] == 0 && !visited[nx][ny][1]) {
+                        visited[nx][ny][1] = true;
+                        dist[nx][ny] = dist[current[0]][current[1]] + 1; // 이동거리 업데이트
+                        q.offer(new int[]{nx, ny, 1});
+                    }
+                } else {
+                    if (!visited[nx][ny][current[2]]) {
+                        visited[nx][ny][current[2]] = true;
+                        dist[nx][ny] = dist[current[0]][current[1]] + 1;
+                        q.offer(new int[]{nx, ny, current[2]});
+                    }
+                }
+
+                if (nx == n - 1 && ny == m - 1) {
+                    return dist[nx][ny] + 1;
+                }
+            }
+        }
+        return -1;
+    }
+
+}

--- a/동기/20221115.java
+++ b/동기/20221115.java
@@ -17,7 +17,7 @@ public class Main {
         int n = Integer.parseInt(split[0]);
         int m = Integer.parseInt(split[1]);
         
-        if (n - 1 == 0 && m - 1 == 0) {
+        if (n == 1 && m == 1) {
             System.out.println(1);
             System.exit(0);
         }


### PR DESCRIPTION
## 접근방법

- 맵을 순회하기 위해 `bfs` 를 사용합니다
- 일반적인 2차원 boolean 배열을 사용하여 방문 체크를 하면 다음과 같은 문제가 발생하게 됩니다
  - 벽을 한 번 부수고 이동하다 막다른 길이 나타나면 벽을 부수지 않는 다른 방향으로 시도해보아야합니다
  - 2차원 boolean 배열을 사용하면 이미 방문 처리가 되었기 때문에 다른 방향으로 시도할 수 없게됩니다
- 그렇기 때문에 **벽을 부수지 않고 진행하는 케이스와 벽을 부수고 진행하는 케이스를 방문 처리 할 수 있는 boolean 배열을 선언합니다**

3차원으로 boolean 배열을 선언합니다
```java
// 2개의 n * m 방문 배열을 만들고 각각 0, 1은 벽을 부수지 않았을 때와 벽을 부쉈을 때 방문 처리를 합니다
boolean[][][] visited = new boolean[n][m][2];
```

- `Queue` 에 좌표를 넣어줄 때 벽을 부쉈는지 상태도 함께 넣어주도록 합니다
  - 0, 0부터 맵을 순회할 때는 벽을 부수지 않았기에 벽을 부수지 않은 상태라는 의미로 0을 하나 더 넣습니다 `ex) q.offer(new int[]{0, 0, 0});`
- 다음 이동할 좌표가 벽이라면 `벽을 부순 적이 있는지 체크합니다
  - 벽 부숨 상태가 0이라면 부순 적이 없으므로 해당 좌표를 방문할 수 있게됩니다
  - 1번 방문 배열에 방문 처리를 해주고 이동한 거리를 업데이트 해줍니다
  - 다시 `Queue` 에 좌표를 넣어줄 때는 벽을 한 번 부쉈기 때문에 벽 부숨 상태를 `1` 로 넣어줍니다 `ex) q.offer(new int[]{x, y, 1)};`
- 다음 이동할 좌표가 벽이 아니라면 방문 가능한 좌표인지 체크합니다
  - 방문한 적이 없다면 방문 체크를 하고 이동 거리도 업데이트 해줍니다
  - 다음 좌표를 방문하기 위해 `Queue` 에 좌표를 넣어줍니다
- 맵의 끝까지 방문했다면 업데이트한 이동 거리를 반환해주고 끝까지 방문하지 못했다면 `-1` 을 반환해줍니다

`+` 

맵은 `1 * 1` 부터 입력되고 시작 칸과 끝나는 칸도 포함하여 반환하여야 하기 때문에 n, m 이 1로 입력되었을 때 반환 값을 따로 처리해주어야 합니다

## 내 풀이의 시간복잡도

O(n^2)

## 참고자료

https://iseunghan.tistory.com/316

## 고민사항, 질문

## 리뷰받고 싶은 부분
